### PR TITLE
fix: Add .gitignore exception for .claude/empire_context.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,8 @@ result-*
 .ai_rules/
 .gemini/
 .qwen/
+.claude/
+!.claude/empire_context.yaml
 .ai_worktrees/
 log/
 logs/


### PR DESCRIPTION
Closes #60

This PR adds `.claude/` to `.gitignore` and includes an exception for `.claude/empire_context.yaml` to prevent worker agents from accidentally deleting the empire context file in PRs.