### PR TITLE
feat: only run review_and_continue stop hook when agent is fullyIdle

### DIFF
--- a/hitl_cli/hooks/review_and_continue.py
+++ b/hitl_cli/hooks/review_and_continue.py
@@ -6,6 +6,7 @@ This hook intercepts Claude's stop events, extracts the last assistant message,
 and sends it to a human for review via the HITL notification system.
 """
 import json
+import os
 import subprocess
 import sys
 import time
@@ -172,6 +173,18 @@ def main():
     except json.JSONDecodeError as e:
         print(f"HITL Stop Hook: Failed to parse input: {e}", file=sys.stderr)
         sys.exit(1)
+
+    # Detect if we are in Antigravity scope
+    is_antigravity = ("--antigravity" in sys.argv) or (os.environ.get("IS_ANTIGRAVITY") == "1")
+
+    # In Antigravity Stop hooks, 'fullyIdle' indicates whether background/async tasks are done
+    if is_antigravity and not input_data.get("fullyIdle", False):
+        output = {
+            "decision": "block",
+            "reason": "Agent is not fully idle. Waiting for background tasks to complete."
+        }
+        print(json.dumps(output))
+        sys.exit(0)
 
     # NOTE: We intentionally do NOT check stop_hook_active here.
     # We want the hook to ALWAYS prompt the user until they say "YOU ARE DONE",

--- a/review_and_continue_antigravity.py
+++ b/review_and_continue_antigravity.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+import os
 import subprocess
 import sys
 import time
@@ -35,6 +36,18 @@ def main():
     except Exception as e:
         print(f"Antigravity Hook Error: {e}", file=sys.stderr)
         sys.exit(1)
+
+    # Detect if we are in Antigravity scope
+    is_antigravity = ("--antigravity" in sys.argv) or (os.environ.get("IS_ANTIGRAVITY") == "1")
+
+    # In Antigravity Stop hooks, 'fullyIdle' indicates whether background/async tasks are done
+    if is_antigravity and not input_data.get("fullyIdle", False):
+        output = {
+            "decision": "block",
+            "reason": "Agent is not fully idle. Waiting for background tasks to complete."
+        }
+        print(json.dumps(output))
+        sys.exit(0)
         
     transcript_path = input_data.get("transcriptPath") or input_data.get("transcript_path")
     if not transcript_path:

--- a/review_and_continue_wrapper.sh
+++ b/review_and_continue_wrapper.sh
@@ -2,5 +2,8 @@
 # Set HITL_API_KEY for correct agent attribution
 export HITL_API_KEY=mcp_pk_jf47fiJt6QknNHchh9xeLDHkfDx2q4p8ZNiqtbso5g0
 
+# Set IS_ANTIGRAVITY to let the hook know it's running under Antigravity
+export IS_ANTIGRAVITY=1
+
 # Capture incoming JSON and run the rebuilt compiled stop hook binary
-tee /Users/slaser79/lab/hitl/hitl-cli/debug_stdin.json | /Users/slaser79/lab/hitl/hitl-cli/result/bin/hitl-hook-review-and-continue
+tee /Users/slaser79/lab/hitl/hitl-cli/debug_stdin.json | /Users/slaser79/lab/hitl/hitl-cli/result/bin/hitl-hook-review-and-continue --antigravity

--- a/tests/hooks/test_review_and_continue.py
+++ b/tests/hooks/test_review_and_continue.py
@@ -287,3 +287,80 @@ def test_main_hook_blocks_on_multi_line_with_instructions(temp_transcript_simple
                     assert output["decision"] == "block"
                     assert "README" in output["reason"]
                     assert "YOU ARE DONE" in output["reason"]
+
+
+def test_main_hook_blocks_when_not_fully_idle_under_antigravity(temp_transcript_simple):
+    """Test that under Antigravity, if the agent is not fully idle, the stop is blocked."""
+    input_data = {
+        "transcript_path": temp_transcript_simple,
+        "fullyIdle": False
+    }
+
+    with patch("hitl_cli.hooks.review_and_continue.json.load", return_value=input_data):
+        with patch("hitl_cli.hooks.review_and_continue.sys.argv", ["review_and_continue.py", "--antigravity"]):
+            with patch("hitl_cli.hooks.review_and_continue.subprocess.run") as mock_run:
+                with patch("hitl_cli.hooks.review_and_continue.sys.exit") as mock_exit:
+                    mock_exit.side_effect = SystemExit(0)
+                    with patch("builtins.print") as mock_print:
+                        try:
+                            review_and_continue.main()
+                        except SystemExit:
+                            pass
+
+                        # Should not call notify-completion (subprocess.run)
+                        mock_run.assert_not_called()
+                        
+                        # Should print a block decision
+                        mock_print.assert_called()
+                        call_args = mock_print.call_args[0][0]
+                        output = json.loads(call_args)
+                        assert output["decision"] == "block"
+                        assert "not fully idle" in output["reason"]
+                        mock_exit.assert_called_with(0)
+
+
+def test_main_hook_prompts_when_not_fully_idle_without_antigravity(temp_transcript_simple):
+    """Test that without Antigravity scope, fullyIdle=False is ignored and human prompt occurs."""
+    input_data = {
+        "transcript_path": temp_transcript_simple,
+        "fullyIdle": False
+    }
+
+    with patch("hitl_cli.hooks.review_and_continue.json.load", return_value=input_data):
+        with patch("hitl_cli.hooks.review_and_continue.sys.argv", ["review_and_continue.py"]):
+            with patch.dict("os.environ", {}):
+                with patch("hitl_cli.hooks.review_and_continue.subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(stdout="✅ Human response received: YOU ARE DONE", returncode=0)
+                    with patch("hitl_cli.hooks.review_and_continue.sys.exit") as mock_exit:
+                        mock_exit.side_effect = SystemExit(0)
+                        try:
+                            review_and_continue.main()
+                        except SystemExit:
+                            pass
+
+                        # Should call notify-completion (subprocess.run)
+                        mock_run.assert_called_once()
+                        mock_exit.assert_called_with(0)
+
+
+def test_main_hook_prompts_when_fully_idle_under_antigravity(temp_transcript_simple):
+    """Test that under Antigravity, if the agent is fully idle, human prompt occurs."""
+    input_data = {
+        "transcript_path": temp_transcript_simple,
+        "fullyIdle": True
+    }
+
+    with patch("hitl_cli.hooks.review_and_continue.json.load", return_value=input_data):
+        with patch("hitl_cli.hooks.review_and_continue.sys.argv", ["review_and_continue.py", "--antigravity"]):
+            with patch("hitl_cli.hooks.review_and_continue.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(stdout="✅ Human response received: YOU ARE DONE", returncode=0)
+                with patch("hitl_cli.hooks.review_and_continue.sys.exit") as mock_exit:
+                    mock_exit.side_effect = SystemExit(0)
+                    try:
+                        review_and_continue.main()
+                    except SystemExit:
+                        pass
+
+                    # Should call notify-completion (subprocess.run)
+                    mock_run.assert_called_once()
+                    mock_exit.assert_called_with(0)


### PR DESCRIPTION
## Summary
This PR modifies the `review_and_continue` stop hook logic to only prompt the human for review when the agent is fully idle (specifically when running in the scope of Google Antigravity). This avoids premature prompting when background/asynchronous tasks are still running. Claude Code sessions remain unaffected.

Refs #75

## Changes
- `review_and_continue_wrapper.sh`: Set `IS_ANTIGRAVITY=1` and pass `--antigravity` flag to the underlying hook script.
- `hitl_cli/hooks/review_and_continue.py`: Check if running in Antigravity scope (using sys.argv or env var), and exit early returning a block decision if `fullyIdle` is False.
- `review_and_continue_antigravity.py`: Sync logic with the same early exit / block check.
- `tests/hooks/test_review_and_continue.py`: Add unit tests covering all target cases:
  - Mock stdin with `fullyIdle: false` and `--antigravity` flag blocks stop.
  - Mock stdin with `fullyIdle: false` but WITHOUT `--antigravity` flag does NOT block (Claude Code fallback).
  - Mock stdin with `fullyIdle: true` and `--antigravity` flag does NOT block.

## Test Plan
- Verified via automated tests: `uv run pytest tests/` (137 tests passed, including the new ones).
- Verified via manual verification.